### PR TITLE
chore: Add README link to hard forked ReVanced repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Morphe Library powers projects such as [Morphe Manager](https://github.com/Morph
 [Morphe CLI](https://github.com/MorpheApp/morphe-cli) with common utilities and functionalities
 by providing shared code.
 
-Morphe Library is based off the work of [ReVanced](https://github.com/ReVanced/revanced-library). All modifications made by Morphe, along with their dates, can be found in the Git history.
+Morphe Library is based off the prior work of [ReVanced](https://github.com/ReVanced/revanced-library). All modifications made by Morphe, along with their dates, can be found in the Git history.
 
 ## 💪 Features
 


### PR DESCRIPTION
Adds a link to ReVanced mentioning the origin source before Morphe modifications, since Morphe is a divergent hard fork of ReVanced with a severed upstream connection to ReVanced.